### PR TITLE
Make .theme file phpcs compliant.

### DIFF
--- a/nicsdru_origins_theme.theme
+++ b/nicsdru_origins_theme.theme
@@ -12,13 +12,8 @@ use Drupal\Core\Form\FormStateInterface;
  * Implements hook_preprocess_HOOK() for html.html.twig.
  */
 function nicsdru_origins_theme_preprocess_html(array &$variables) {
-  /* Add class to html tag */
+  // Add class to html tag.
   $variables['html_attributes']->addClass('no-js');
-
-  // Don't display the site name twice on the front page (and potentially others)
-  /*if (isset($variables['head_title_array']['title']) && isset($variables['head_title_array']['name']) && ($variables['head_title_array']['title'] == $variables['head_title_array']['name'])) {
-    $variables['head_title'] = $variables['head_title_array']['name'];
-  }*/
 }
 
 /**
@@ -43,18 +38,20 @@ function nicsdru_origins_theme_preprocess(&$variables) {
  * Implements hook_page_attachments_alter().
  */
 function nicsdru_origins_theme_page_attachments_alter(array &$page) {
-  // Tell IE to use latest rendering engine (not to use compatibility mode).
-  /*$ie_edge = [
-    '#type' => 'html_tag',
-    '#tag' => 'meta',
-    '#attributes' => [
-    'http-equiv' => 'X-UA-Compatible',
-    'content' => 'IE=edge',
-    ],
-  ];
-  $page['#attached']['html_head'][] = [$ie_edge, 'ie_edge'];*/
+  /*
+   * Tell IE to use latest rendering engine (not to use compatibility mode).
+   * /*$ie_edge = [
+   *   '#type' => 'html_tag',
+   *   '#tag' => 'meta',
+   *   '#attributes' => [
+   *   'http-equiv' => 'X-UA-Compatible',
+   *   'content' => 'IE=edge',
+   *   ],
+   * ];
+   * $page['#attached']['html_head'][] = [$ie_edge, 'ie_edge'];
+   */
 
-  // Attach our drupal components library for authenticated users
+  // Attach our drupal components library for authenticated users.
   $userCurrent = \Drupal::currentUser();
 
   if ($userCurrent->isAuthenticated()) {
@@ -68,124 +65,82 @@ function nicsdru_origins_theme_page_attachments_alter(array &$page) {
  * Implements hook_preprocess_page() for page.html.twig.
  */
 function nicsdru_origins_theme_preprocess_page(array &$variables) {
-
 }
-
-/**
- * Implement hook_theme()
- */
-//function nicsdru_origins_theme_theme() {
-//  return [
-//    'nics_2_cols' => [
-//      'template' => 'templates/layout/nics-layout-2-cols',
-//      // layout_plugin expects the theme hook to be declared with this:
-//      'render element' => 'content',
-//    ],
-//  ];
-//}
 
 /**
  * Implements hook_theme_suggestions_page_alter().
  */
 function nicsdru_origins_theme_theme_suggestions_page_alter(array &$suggestions, array $variables) {
-
 }
 
 /**
  * Implements hook_theme_suggestions_node_alter().
  */
 function nicsdru_origins_theme_theme_suggestions_node_alter(array &$suggestions, array $variables) {
-  /*$node = $variables['elements']['#node'];
-
-  if ($variables['elements']['#view_mode'] == "full") {
-
-  }*/
 }
 
 /**
  * Implements hook_preprocess_HOOK() for Block document templates.
  */
 function nicsdru_origins_theme_preprocess_block(array &$variables) {
-
 }
 
 /**
  * Implements hook_theme_suggestions_field_alter().
  */
 function nicsdru_origins_theme_theme_suggestions_field_alter(array &$suggestions, array $variables) {
-  /*$element = $variables['element'];
-  $suggestions[] = 'field__' . $element['#view_mode'];
-  $suggestions[] = 'field__' . $element['#view_mode'] . '__' . $element['#field_name'];*/
 }
 
 /**
  * Implements hook_theme_suggestions_field_alter().
  */
 function nicsdru_origins_theme_theme_suggestions_fieldset_alter(array &$suggestions, array $variables) {
-  /*$element = $variables['element'];
-  if (isset($element['#attributes']['class']) && in_array('form-composite', $element['#attributes']['class'])) {
-    $suggestions[] = 'fieldset__form_composite';
-  }*/
 }
 
 /**
  * Implements hook_preprocess_node().
  */
 function nicsdru_origins_theme_preprocess_node(array &$variables) {
-  // Default to turning off byline/submitted.
-  //$variables['display_submitted'] = FALSE;
 }
 
 /**
  * Implements hook_theme_suggestions_views_view_alter().
  */
 function nicsdru_origins_theme_theme_suggestions_views_view_alter(array &$suggestions, array $variables) {
-
 }
 
 /**
  * Implements hook_preprocess_form().
  */
 function nicsdru_origins_theme_preprocess_form(array &$variables) {
-  // add class to default site search form
-//  if ($variables['attributes']['id'] == 'search-block-form') {
-//    $variables['attributes']['class'][] = 'site-search-form';
-//  }
 }
 
 /**
  * Implements hook_preprocess_select().
  */
 function nicsdru_origins_theme_preprocess_select(array &$variables) {
-  //$variables['attributes']['class'][] = 'select-chosen';
 }
 
 /**
  * Implements hook_preprocess_field().
  */
 function nicsdru_origins_theme_preprocess_field(array &$variables, $hook) {
-  /*switch ($variables['element']['#field_name']) {
-  }*/
 }
 
 /**
  * Implements hook_preprocess_details().
  */
 function nicsdru_origins_theme_preprocess_details(array &$variables) {
-  /*$variables['attributes']['class'][] = 'details';
-  $variables['summary_attributes']['class'] = 'summary';*/
 }
 
 /**
  * Implements hook_theme_suggestions_details_alter().
  */
 function nicsdru_origins_theme_theme_suggestions_details_alter(array &$suggestions, array $variables) {
-
 }
 
 /**
  * Implements hook_preprocess_menu_local_task().
  */
 function nicsdru_origins_theme_preprocess_menu_local_task(array &$variables) {
-  //$variables['element']['#link']['url']->setOption('attributes', ['class'=>'rounded']);
 }


### PR DESCRIPTION
- Comment styles tweaked to show how they shoudl be.
- Placeholder code stripped away, should not really be present: use git
history instead for finding older code to ensure functioning code is as
lean is possible and not cluttered with things left to do.

Have left boilerplate hook implementation functions as the runtime
overhead for these is negligible.