### PR TITLE
Add CI checks

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,24 @@
+# CircleCI service overview
+
+This service runs a number of discrete testing steps, defined as jobs in `.circleci/config.yml`.
+
+See https://circleci.com/docs/2.0 for configuration file/language specifications.
+
+Environment variable usage is encouraged to safeguard sensitive values, but usage can be fiddly as interpolation in parts of the config file will work in some parts but not others.
+
+## Running locally
+
+It is possible to debug/run the pipeline locally using the CircleCI Local CLI tool.
+
+See https://circleci.com/docs/2.0/local-cli/ for installation and further details.
+
+> TL;DR:
+
+- Install with: `brew install circleci`
+- Run individual jobs like this: `circleci local execute --job YOUR_JOB_NAME -e GITHUB_TOKEN=YOUR-TOKEN-VALUE -e ANOTHER_VAR=another_value`
+  - Note how environmental variables from CircleCI are not accessible outside of that platform. You need to pass them in as per above when running locally. That might be tricky if you don't have a certain key value; CircleCI's environment variable browser will not show you the raw value once the variable has been created.
+- Features such as parallelism, workspace sharing and directory caching won't work. You may need to adjust your job's execution steps to compensate for this.
+
+## Interaction with other supporting repos/services
+
+This is a supporting project for the NIDirect site. It provides basic, but helpful, checks to trap simple issues earlier on. The full site test pipeline at https://github.com/dof-dss/nidirect-drupal will run whenever a new version of this project is referenced from the `composer.lock` file of the main repo; eg: after a `composer update dof-dss/<projectname> --with-depdendencies` command.

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -21,4 +21,4 @@ See https://circleci.com/docs/2.0/local-cli/ for installation and further detail
 
 ## Interaction with other supporting repos/services
 
-This is a supporting project for the NIDirect site. It provides basic, but helpful, checks to trap simple issues earlier on. The full site test pipeline at https://github.com/dof-dss/nidirect-drupal will run whenever a new version of this project is referenced from the `composer.lock` file of the main repo; eg: after a `composer update dof-dss/<projectname> --with-depdendencies` command.
+This is a supporting project for the NIDirect site. It provides basic, but helpful, checks to trap simple issues earlier on. The full site test pipeline at https://github.com/dof-dss/nidirect-drupal will run whenever a new version of this project is referenced from the `composer.lock` file of the main repo; eg: after a `composer update dof-dss/projectname --with-depdendencies` command.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,72 @@
+# PHP CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-php/ for more details
+version: 2
+
+jobs:
+  # Code linting.
+  lint:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - node_modules-{{ checksum "package.json" }}
+      - run:
+          name: Fetch dependencies
+          command: npm install
+      - save_cache:
+          key: node_modules-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run:
+          name: Lint all code
+          command: |
+            npm run lint
+
+  build-styleguide:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - node_modules-{{ checksum "package.json" }}
+      - run:
+          name: Fetch dependencies
+          command: npm install
+      - save_cache:
+          key: node_modules-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run:
+          name: Configure and build KSS styleguide
+          command: npm run kss
+
+  build-assets:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - node_modules-{{ checksum "package.json" }}
+      - run:
+          name: Fetch dependencies
+          command: npm install
+      - save_cache:
+          key: node_modules-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run:
+          name: Compile SCSS and JS assets
+          command: npm run build
+
+workflows:
+  version: 2
+  lint-build:
+    jobs:
+      - lint
+      - build-styleguide
+      - build-assets

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
This PR provides CircleCI jobs to:

- Run all code linters
- Test the build of the styleguide
- Compile all SCSS/JS assets

NB: the first two tasks presently fail due to a lack of JS files to lint and lack of config for KSS styleguide. Once those are present, they should pass.