### PR TITLE
Add a visually hidden label to the site search form

### DIFF
--- a/nicsdru_origins_theme.theme
+++ b/nicsdru_origins_theme.theme
@@ -175,6 +175,13 @@ function nicsdru_origins_theme_preprocess_views_view(&$variables) {
   if ($variables['id'] === 'search') {
     $variables['exposed']['#attributes']['class'][] = Html::cleanCssIdentifier('search-form');
     $variables['exposed']['#attributes']['class'][] = Html::cleanCssIdentifier('search-form--site');
+    // If a label for the search input is not defined in the view, set default label text.
+    $search_label =& $variables['exposed']['#info']['filter-search_api_fulltext']['label'];
+    if (isset($search_label) && empty($search_label)) {
+      $search_label = "Search this site";
+    }
+    // The label should be visually hidden.
+    $variables['exposed']['query']['#title_display'] = 'invisible';
   }
 }
 

--- a/nicsdru_origins_theme.theme
+++ b/nicsdru_origins_theme.theme
@@ -178,7 +178,7 @@ function nicsdru_origins_theme_preprocess_views_view(&$variables) {
     // If a label for the search input is not defined in the view, set default label text.
     $search_label =& $variables['exposed']['#info']['filter-search_api_fulltext']['label'];
     if (isset($search_label) && empty($search_label)) {
-      $search_label = "Search this site";
+      $search_label = t("Search this site");
     }
     // The label should be visually hidden.
     $variables['exposed']['query']['#title_display'] = 'invisible';


### PR DESCRIPTION
Modifies nicsdru_origins_theme_preprocess_views_view to add a label for the search input and visually hide it.