### PR TITLE
Add templates for HTTP 403/404 reponses

### DIFF
--- a/templates/misc/page--403.html.twig
+++ b/templates/misc/page--403.html.twig
@@ -65,7 +65,17 @@
 {{- page.help -}}
 {{- page.top_banner -}}
 <main{{ main_content_attr }}>{# @see skiplink in html.html.twig  which targets the ID for this element #}
-  {{- page.content -}}
+  <h1>Page not found</h1>
+  <p><strong>Sorry, we can't find the page you're looking for.</strong></p>
+  <p>If you have typed the URL directly into the address bar in your browser please check it's right.
+    If you got here following a link from another website, that link may no longer be correct.</p>
+  <h2>Here are some options</h2>
+  <p>If you're having trouble finding the information you want, try <a href="/search">Search</a> or the following pages:</p>
+  <ul>
+    <li><a href="/">Home page</a></li>
+    <li><a href="/sitemap">Sitemap</a></li>
+    <li><a href="/contacts">Contacts</a></li>
+  </ul>
 </main>
 {%- if page.bottom_banner -%}
   {{- page.bottom_banner -}}

--- a/templates/misc/page--403.html.twig
+++ b/templates/misc/page--403.html.twig
@@ -1,0 +1,77 @@
+{#
+/**
+ * @file
+ * Theme override to show an HTTP 403 access denied response.
+ *
+ * These responses are usually covered by page.tpl.php in Core with a system callback to
+ * generate the content for the message. To customise the message, you can either preprocess
+ * or override the controller for it, or remove the `page.content` variable in this template
+ * and replace with any text you like.
+ *
+ * See nidirect_errorpages.module for suggesteed template candidates.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - messages: Status and error messages. Should be displayed prominently.
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.top_banner: Items for the top banner region.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.bottom_banner: Items for the bottom banner region.
+ * - page.footer: Items for the footer region.
+ *
+ * Attributes:
+ * - main_content_attr: HTML attributes for the main containing element.
+ * - sidebar_first_attr: Same as main_content_attr, except applied to the first sidebar
+ * - sidebar_second_attr: Same as main_content_attr, except applied to the second sidebar
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+<header class="header">
+  {{- page.header -}}
+</header>
+{{- page.primary_menu -}}
+{{- page.secondary_menu -}}
+{{- page.highlighted -}}
+{{- page.help -}}
+{{- page.top_banner -}}
+<main{{ main_content_attr }}>{# @see skiplink in html.html.twig  which targets the ID for this element #}
+  {{- page.content -}}
+</main>
+{%- if page.bottom_banner -%}
+  {{- page.bottom_banner -}}
+{% endif %}
+{%- if page.footer -%}
+  <footer id="footer" class="footer">
+    {{- page.footer -}}
+  </footer>
+{%- endif -%}

--- a/templates/misc/page--404.html.twig
+++ b/templates/misc/page--404.html.twig
@@ -1,0 +1,85 @@
+{#
+/**
+ * @file
+ * Theme override to show an HTTP 404 page not found response.
+ *
+ * These responses are usually covered by page.tpl.php in Core with a system callback to
+ * generate the content for the message. To customise the message, you can either preprocess
+ * or override the controller for it, or remove the `page.content` variable in this template
+ * and replace with any text you like.
+ *
+ * See nidirect_errorpages.module for suggesteed template candidates.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template.
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - messages: Status and error messages. Should be displayed prominently.
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.top_banner: Items for the top banner region.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.bottom_banner: Items for the bottom banner region.
+ * - page.footer: Items for the footer region.
+ *
+ * Attributes:
+ * - main_content_attr: HTML attributes for the main containing element.
+ * - sidebar_first_attr: Same as main_content_attr, except applied to the first sidebar
+ * - sidebar_second_attr: Same as main_content_attr, except applied to the second sidebar
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+<header class="header">
+  {{- page.header -}}
+</header>
+{{- page.primary_menu -}}
+{{- page.secondary_menu -}}
+{{- page.highlighted -}}
+{{- page.help -}}
+{{- page.top_banner -}}
+<main{{ main_content_attr }}>{# @see skiplink in html.html.twig  which targets the ID for this element #}
+  <h1>Page not found</h1>
+  <p><strong>Sorry, we can't find the page you're looking for.</strong></p>
+  <p>If you have typed the URL directly into the address bar in your browser please check it's right.
+    If you got here following a link from another website, that link may no longer be correct.</p>
+  <h2>Here are some options</h2>
+  <p>If you're having trouble finding the information you want, try Search or the following pages:</p>
+  <ul>
+    <li>Home page</li>
+    <li>Sitemap</li>
+    <li>Contacts</li>
+  </ul>
+</main>
+{%- if page.bottom_banner -%}
+  {{- page.bottom_banner -}}
+{% endif %}
+{%- if page.footer -%}
+  <footer id="footer" class="footer">
+    {{- page.footer -}}
+  </footer>
+{%- endif -%}

--- a/templates/misc/page--404.html.twig
+++ b/templates/misc/page--404.html.twig
@@ -68,11 +68,11 @@
   <p>If you have typed the URL directly into the address bar in your browser please check it's right.
     If you got here following a link from another website, that link may no longer be correct.</p>
   <h2>Here are some options</h2>
-  <p>If you're having trouble finding the information you want, try Search or the following pages:</p>
+  <p>If you're having trouble finding the information you want, try <a href="/search">Search</a> or the following pages:</p>
   <ul>
-    <li>Home page</li>
-    <li>Sitemap</li>
-    <li>Contacts</li>
+    <li><a href="/">Home page</a></li>
+    <li><a href="/sitemap">Sitemap</a></li>
+    <li><a href="/contacts">Contacts</a></li>
   </ul>
 </main>
 {%- if page.bottom_banner -%}


### PR DESCRIPTION
Stored in the origins repo, as these are re-usable between sites.

- Breadcrumb is removed by simply not printing its value in the templates.
- Template suggestions are set in `nidirect_errorpages.module`.