### PR TITLE
Circle CI refinements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,15 +54,10 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libpng-dev
             sudo docker-php-ext-install gd
-      - restore_cache:
-          key: global-composer-{{ checksum "/home/circleci/.composer/composer.lock" }}
+      - checkout
       - run:
           name: Add hirak/prestissimo for faster composer downloads
           command: composer global require hirak/prestissimo
-      - save_cache:
-          key: global-composer-{{ checksum "/home/circleci/.composer/composer.lock" }}
-          paths:
-            - /home/circleci/project/.composer/cache
       - attach_workspace:
           at: ./
       - restore_cache:
@@ -82,11 +77,11 @@ jobs:
           name: Fetch phpcs convenience script
           command: |
             cd /home/circleci
-            curl https://raw.githubusercontent.com/dof-dss/nidirect-drupal/development/phpcs.sh -o /home/circleci/phpcs.sh
+            curl https://raw.githubusercontent.com/dof-dss/nidirect-drupal/master/phpcs.sh -o /home/circleci/phpcs.sh
             # Enable ignore variable.
             sed -i -e "s/\#IGNORE/IGNORE/" phpcs.sh
             # Add unwanted paths to this ignore variable.
-            sed -i -e "s/web\/themes\/custom\/nicsdru_origins_theme\/node_modules/project\/node_modules/" phpcs.sh
+            sed -i -e "s/web\/themes\/custom\/THEMENAME\/node_modules/project\/node_modules,\${DRUPAL_DEPLOY_PATH}\/vendor/" phpcs.sh
             # Make the file executable.
             chmod +x /home/circleci/phpcs.sh
       - run:
@@ -136,7 +131,7 @@ jobs:
             # Enable ignore variable.
             sed -i -e "s/\#IGNORE/IGNORE/" phpcs.sh
             # Add unwanted paths to this ignore variable.
-            sed -i -e "s/web\/themes\/custom\/nicsdru_origins_theme\/node_modules/project\/node_modules/" phpcs.sh
+            sed -i -e "s/web\/themes\/custom\/THEMENAME\/node_modules/project\/node_modules,\${DRUPAL_DEPLOY_PATH}\/vendor/" phpcs.sh
             # Make the file executable.
             chmod +x /home/circleci/phpcs.sh
             cat /home/circleci/phpcs.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 styleguide
 css/**/*.css.map
+vendor

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,19 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "60a5d87a7539ca10d73cf772fe941173",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=7.0"
+    },
+    "platform-dev": []
+}


### PR DESCRIPTION
Mirrors what is in nicsdru_nidirect_theme, this will:

- Correctly exclude node_modules and vendor directories so we don't waste build minutes scanning through lots of things we're not interested in.
- Define a composer.lock file so that package versions are nailed down for local development (these can always be updated/changed if the project is subthemed/forked). We also use this file as a basis for fingerprinting the Circle CI cache items; may as well fetch from cache until this file changes.
- Add the checkout step in the phpcs job, because the task + workspace in the build step doesn't persist, so we'd be evaluating on empty code giving a false sense of security.