### PR TITLE
A11y fixes

### DIFF
--- a/templates/field/image.html.twig
+++ b/templates/field/image.html.twig
@@ -10,4 +10,4 @@
  * @see template_preprocess_image()
  */
 #}
-<img{{ attributes|without('alt') }} alt="{{ alt }}" />
+<img{{ attributes|without('alt')|without('caption') }} alt="{{ alt }}" />

--- a/templates/field/image.html.twig
+++ b/templates/field/image.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override of an image.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the img tag.
+ * - style_name: (optional) The name of the image style applied.
+ *
+ * @see template_preprocess_image()
+ */
+#}
+<img{{ attributes|without('alt') }} alt="{{ alt }}" />

--- a/templates/field/responsive-image.html.twig
+++ b/templates/field/responsive-image.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+ * @file
+ * Theme override of a responsive image.
+ *
+ * Available variables:
+ * - sources: The attributes of the <source> tags for this <picture> tag.
+ * - img_element: The controlling image, with the fallback image in srcset.
+ * - output_image_tag: Whether or not to output an <img> tag instead of a
+ *   <picture> tag.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_responsive_image()
+ */
+#}
+
+{% if img_element['#attributes'].caption %}
+  <figure>
+{% endif %}
+{% if output_image_tag %}
+    {{ img_element }}
+{% else %}
+    <picture data-picture-mapping="{{ responsive_image_style_id }}">
+      {% if sources %}
+        {% for srcset in sources %}
+          <source{{ srcset }} />
+        {% endfor %}
+      {% endif %}
+      {# The controlling image, with the fallback image in srcset. #}
+      {{ img_element }}
+    </picture>
+{% endif %}
+{% if img_element['#attributes'].caption %}
+    <figcaption class="field-file-image-caption-text">{{ img_element['#attributes'].caption }}</figcaption>
+  </figure>
+{% endif %}
+


### PR DESCRIPTION
- Ensure null alt attributes are output
- Remove caption attributes from img (use figure / figcaption instead)
- Responsive image twig migrated from nidirect theme

Related PRs:
- https://github.com/dof-dss/nidirect-drupal/pull/582
- https://github.com/dof-dss/nicsdru_nidirect_theme/pull/228