### PR TITLE
drupal-diff.css should be added as a library override rather than an …

### DIFF
--- a/nicsdru_origins_theme.info.yml
+++ b/nicsdru_origins_theme.info.yml
@@ -36,7 +36,7 @@ libraries-override:
   diff/diff.general:
     css:
       theme:
-        css/diff.general.css: false
+        css/diff.general.css: css/drupal-diff.css
 
 libraries-extend:
   core/drupal.autocomplete:

--- a/nicsdru_origins_theme.libraries.yml
+++ b/nicsdru_origins_theme.libraries.yml
@@ -27,7 +27,6 @@ authenticated-styles:
   css:
     theme:
       css/drupal-admin.css: { minified: true, weight: -5 }
-      css/drupal-diff.css: { minified: true, weight: -6 }
 
 # Provide a custom modernizer script
 nics-modernizr:
@@ -93,4 +92,3 @@ moderation-sidebar:
     - core/drupal
     - core/jquery
     - core/jquery.once
-


### PR DESCRIPTION
…authenticated style and ensures it is only loaded when doing a revision comparison