### PR TITLE
Add library to permit themes/modules to re-use generated CSS for file icons

### DIFF
--- a/nicsdru_origins_theme.libraries.yml
+++ b/nicsdru_origins_theme.libraries.yml
@@ -92,3 +92,8 @@ moderation-sidebar:
     - core/drupal
     - core/jquery
     - core/jquery.once
+
+media_library_styles:
+  css:
+    theme:
+      css/3_components/field/file-link.css: { minified: true }


### PR DESCRIPTION
Permits https://github.com/dof-dss/nicsdru_origins_modules/pull/131 to re-use the generated CSS from this theme.

The media table (admin/content/media) and grid (admin/content/media-grid) displays need different SVG icon sizes, because the grid display shows each entity as a larger item. Ideally, these adjustments can be added to the current `src/scss/3_components/field/file-link.scss` file to ensure we have a single place where we can control the display of media preview icons.