### PR TITLE
Wrap facet buttons in a div instead of H3

### DIFF
--- a/templates/block/block--facet-block.html.twig
+++ b/templates/block/block--facet-block.html.twig
@@ -37,7 +37,7 @@
 <div{{ attributes }}>
   {{ title_prefix }}
   {% if label %}
-    <h3{{ title_attributes.addClass('facet--title') }}>{{ 'Filter by'|t }} {{ label|lower }}</h3>
+    <div{{ title_attributes.addClass('facet--title') }}>{{ 'Filter by'|t }} {{ label|lower }}</div>
   {% endif %}
   {{ title_suffix }}
   {% block content %}


### PR DESCRIPTION
For search pages, the search form and facets is presented after the H1 in the DOM.  Wrapping the facet dropdown toggle buttons in H3 breaks the correct heading structure for the page.  Instead wrap the facet dropdown toggles in a DIV.